### PR TITLE
climate: cap-freeze (vendored) + live swing options + fan blank-tile + swing-label translations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install deps
+        # pytest-homeassistant-custom-component pulls a real Home Assistant, which
+        # the unit tests need for the platform modules the conftest does not stub
+        # (number / sensor / binary_sensor / button). jsonschema is used by the
+        # vendored lib's device-quirks schema.
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest-homeassistant-custom-component jsonschema
+      - name: Run unit tests
+        # Integration tests (-m integration) spin up a real HA event loop and are
+        # intentionally excluded from the fast PR gate.
+        run: python -m pytest tests/unit -m "not integration"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+Notable changes to the Blaueis Midea integration.
+
+## [Unreleased]
+
+### Fixed
+- **Vane positions no longer silently break mid-session.** After boot, the
+  device can push unsolicited B5 capability frames that inconsistently report
+  the B0 vane-angle caps (0x09 / 0x0A) as not-supported. These were re-applied
+  live and demoted the angle fields out of the active set, so selecting a vane
+  position became a silent no-op until the next restart. Capabilities are now
+  frozen after the single boot scan: a later B5 may *escalate* availability but
+  can no longer *demote* a field confirmed at boot. Each blocked demotion is
+  logged and counted (`frame_counts.cap_demotions_blocked`) so the source stays
+  observable.
+
+### Changed
+- **Swing / vane option lists are computed live** from current capabilities
+  instead of a cached setup-time snapshot, so the dropdown never offers a
+  position the set path would reject.
+- **Fan: off-grid speeds now show a blank tile** instead of a synthetic
+  "Custom" entry; the fan dropdown lists only the named presets.
+
+### Added
+- Swing / vane-position option labels are now translated (e.g. `upper_middle`
+  → "Upper Middle", `left_center` → "Left Center") instead of rendering raw
+  slugs.

--- a/custom_components/blaueis_midea/climate.py
+++ b/custom_components/blaueis_midea/climate.py
@@ -55,6 +55,12 @@ class BlaueisMideaClimate(ClimateEntity):
 
     _attr_has_entity_name = True
     _attr_name = None  # Use device name
+    # Entity translation_key — maps the climate state-attribute option slugs
+    # (swing_mode / swing_horizontal_mode) to labels in translations/<lang>.json
+    # under entity.climate.blaueis_ac.state_attributes.*. Without it the custom
+    # swing/vane slugs render raw (e.g. "upper_middle"). No top-level `name`
+    # entry is provided, so this stays the device's main (device-named) entity.
+    _attr_translation_key = "blaueis_ac"
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _enable_turn_on_off_backwards_compat = False
     should_poll = False
@@ -78,12 +84,15 @@ class BlaueisMideaClimate(ClimateEntity):
         # Swing & vane-position — per axis (vertical → swing_mode,
         # horizontal → swing_horizontal_mode). Options are built from caps in
         # _axis_options(); an axis with neither swing nor positions is dropped.
+        # Feature presence is decided once at setup (an axis with neither a
+        # swing nor an angle field at boot has no control). The OPTION LISTS are
+        # computed LIVE (swing_modes / swing_horizontal_modes properties below)
+        # from available_fields, so a cap change can never leave the dropdown
+        # offering a vane position that the set path then silently rejects.
         if any(SWING_AXES["vertical"][k] in avail for k in ("swing", "angle")):
             features |= ClimateEntityFeature.SWING_MODE
-            self._attr_swing_modes = self._axis_options("vertical")
         if any(SWING_AXES["horizontal"][k] in avail for k in ("swing", "angle")):
             features |= ClimateEntityFeature.SWING_HORIZONTAL_MODE
-            self._attr_swing_horizontal_modes = self._axis_options("horizontal")
 
         # ── Presets (B5-gated) ─────────────────────────────
         self._available_presets: dict[str, str] = {}  # field_name → preset_name
@@ -116,21 +125,16 @@ class BlaueisMideaClimate(ClimateEntity):
             display = vdef.get("label", key) if isinstance(vdef, dict) else key
             self._fan_name_to_raw[display] = raw
             self._fan_raw_to_name.setdefault(raw, display)
-        custom_vdef = fan_ac.get("custom_value")
-        self._fan_custom_label: str | None = (
-            custom_vdef.get("label") if isinstance(custom_vdef, dict) else None
-        )
         if self._fan_name_to_raw:
-            modes = list(self._fan_name_to_raw.keys())
-            if self._fan_custom_label:
-                modes.append(self._fan_custom_label)
-            self._attr_fan_modes = modes
+            # Option A: an off-grid fan_speed (no named preset for that raw)
+            # surfaces as a blank fan tile (fan_mode -> None), not a synthetic
+            # "Custom" option — the dropdown lists only the real named presets.
+            self._attr_fan_modes = list(self._fan_name_to_raw.keys())
         else:
             # Pre-B5 fallback
             self._attr_fan_modes = list(FAN_PRESET_TO_SPEED.keys())
             self._fan_name_to_raw = dict(FAN_PRESET_TO_SPEED)
             self._fan_raw_to_name = dict(FAN_SPEED_TO_PRESET)
-            self._fan_custom_label = None
 
         # ── Temperature range (B5 constraints) ─────────────
         temp_meta = avail.get("target_temperature", {})
@@ -212,10 +216,8 @@ class BlaueisMideaClimate(ClimateEntity):
         speed = self._device.read("fan_speed")
         if speed is None:
             return None
-        name = self._fan_raw_to_name.get(speed)
-        if name is None and self._fan_custom_label:
-            return self._fan_custom_label
-        return name
+        # Option A: an off-grid raw (no named preset) blanks the tile (None).
+        return self._fan_raw_to_name.get(speed)
 
     # ── Swing / vane-position helpers (per axis) ───────────
     # Mapping logic lives in the HA-free _swing module (unit-tested directly);
@@ -239,6 +241,22 @@ class BlaueisMideaClimate(ClimateEntity):
             return
         result = await self._device.set(**changes)
         check_set_result(result, primary_fields=set(changes))
+
+    @property
+    def swing_modes(self) -> list[str] | None:
+        """Vertical-axis option list, computed live from caps on every read
+        (plain property, not a cached __init__ snapshot — so the offered
+        options always match what the set path will accept)."""
+        if not (self._attr_supported_features & ClimateEntityFeature.SWING_MODE):
+            return None
+        return self._axis_options("vertical")
+
+    @property
+    def swing_horizontal_modes(self) -> list[str] | None:
+        """Horizontal-axis option list, computed live (see ``swing_modes``)."""
+        if not (self._attr_supported_features & ClimateEntityFeature.SWING_HORIZONTAL_MODE):
+            return None
+        return self._axis_options("horizontal")
 
     @property
     def swing_mode(self) -> str | None:
@@ -287,8 +305,6 @@ class BlaueisMideaClimate(ClimateEntity):
             check_set_result(result, primary_fields={"target_temperature"})
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
-        if fan_mode == self._fan_custom_label:
-            fan_mode = "Auto"
         speed = self._fan_name_to_raw.get(fan_mode)
         if speed is not None:
             validate_or_raise(self._coord, "fan_speed", speed)

--- a/custom_components/blaueis_midea/lib/blaueis/client/device.py
+++ b/custom_components/blaueis_midea/lib/blaueis/client/device.py
@@ -960,9 +960,31 @@ class Device:
                 # A B5 sets persistent capability state; pass the wire-integrity
                 # verdict so process_b5 discards a corrupted frame rather than
                 # letting a bad cap byte gate a field off until reload.
+                #
+                # Caps are queried once at boot. Once that scan has finalized,
+                # this is a post-boot B5 (unsolicited, or replayed by the gateway
+                # on a reconnect) — the suspected "cap killer". Log + count it so
+                # its origin is observable, and pass allow_demote=False so it can
+                # escalate/refresh but never silently demote a confirmed field.
+                caps_frozen = self._status.get("meta", {}).get("caps_finalized", False)
+                if caps_frozen:
+                    counts = self._status.setdefault("meta", {}).setdefault(
+                        "frame_counts", {}
+                    )
+                    counts["rsp_0xb5_post_boot"] = (
+                        counts.get("rsp_0xb5_post_boot", 0) + 1
+                    )
+                    log.warning(
+                        "post-boot B5 (caps frozen since boot): crc_ok=%s len=%dB "
+                        "count=%d — demotions will be blocked, escalations applied",
+                        parsed["crc_ok"] and parsed["checksum_ok"], len(body),
+                        counts["rsp_0xb5_post_boot"],
+                    )
+                    log.debug("post-boot B5 body: %s", bytes(body).hex())
                 next_frame = process_b5(
                     self._status, body, self._glossary, timestamp=ts,
                     frame_trusted=parsed["crc_ok"] and parsed["checksum_ok"],
+                    allow_demote=not caps_frozen,
                 )
                 if self._b5_state == "waiting":
                     self._b5_next_frame = next_frame

--- a/custom_components/blaueis_midea/lib/blaueis/core/process.py
+++ b/custom_components/blaueis_midea/lib/blaueis/core/process.py
@@ -29,10 +29,23 @@ from blaueis.core.codec import (
 
 log = logging.getLogger("blaueis.process")
 
+# Availability tiers that mean "the feature is present/usable on this unit".
+# A B5 cap value that moves a field OUT of this set (→ excluded/never) is a
+# demotion; post-boot demotions are the "cap killers" we block + log.
+_AVAILABLE_FA = ("always", "readable", "readable-opt")
+
+
+def _is_cap_demotion(current_fa: str | None, new_fa: str | None) -> bool:
+    """True when ``new_fa`` removes an availability the field currently has."""
+    return current_fa in _AVAILABLE_FA and new_fa not in _AVAILABLE_FA
+
+
 # ── B5 capability processing ─────────────────────────────────────────────
 
 
-def _apply_caps_to_fields(status: dict, records: list[dict], glossary: dict) -> None:
+def _apply_caps_to_fields(
+    status: dict, records: list[dict], glossary: dict, *, allow_demote: bool = True
+) -> None:
     """For each cap record, decode it and update every field that shares the cap_id.
 
     Used by both `process_b5` (real B5 frame path) and `apply_device_quirks`
@@ -71,7 +84,28 @@ def _apply_caps_to_fields(status: dict, records: list[dict], glossary: dict) -> 
 
                 cap_fa = decoded.get("feature_available")
                 if cap_fa and not glossary_pinned_excluded:
-                    status_field["feature_available"] = cap_fa
+                    cur_fa = status_field.get("feature_available")
+                    if not allow_demote and _is_cap_demotion(cur_fa, cap_fa):
+                        # Caps are queried once at boot and then frozen. A later
+                        # device-pushed / reconnect-replayed B5 that reports this
+                        # cap as not-supported must NOT silently gate off a
+                        # feature confirmed at boot (the "cap killer"). Block it,
+                        # count it, and log which cap/field so the source stays
+                        # observable. See finalize_capabilities (caps_finalized).
+                        counts = status.setdefault("meta", {}).setdefault(
+                            "frame_counts", {}
+                        )
+                        counts["cap_demotions_blocked"] = (
+                            counts.get("cap_demotions_blocked", 0) + 1
+                        )
+                        log.warning(
+                            "cap-killer blocked: cap %s would demote %s %s→%s "
+                            "after boot — ignored (caps frozen); blocked count=%d",
+                            cap_id, field_name, cur_fa, cap_fa,
+                            counts["cap_demotions_blocked"],
+                        )
+                    else:
+                        status_field["feature_available"] = cap_fa
 
                 ac = {}
                 for k in ("valid_range", "valid_set", "step", "correction", "slider", "values", "custom_value"):
@@ -114,6 +148,7 @@ def process_b5(
     glossary: dict,
     timestamp: str | None = None,
     frame_trusted: bool = True,
+    allow_demote: bool = True,
 ) -> bool:
     """Process a B5 capability frame and update the status file.
 
@@ -154,8 +189,11 @@ def process_b5(
         existing.append(rec)
     status["capabilities_raw"] = existing
 
-    # Decode each cap and update ALL fields that share this cap_id
-    _apply_caps_to_fields(status, records, glossary)
+    # Decode each cap and update ALL fields that share this cap_id.
+    # allow_demote is forwarded so the steady-state ingress path (post-boot
+    # B5s routed via Device._process_frame) can escalate/refresh but never
+    # silently demote a field confirmed by the one boot capability scan.
+    _apply_caps_to_fields(status, records, glossary, allow_demote=allow_demote)
 
     status["meta"]["b5_received"] = True
     status["meta"]["phase"] = "post_b5"
@@ -182,6 +220,13 @@ def finalize_capabilities(status: dict, glossary: dict):
             cap_id = cap_def.get("cap_id", "").lower()
             if cap_id and cap_id not in all_cap_ids:
                 status_field["feature_available"] = "excluded"
+
+    # The one boot capability scan is complete — freeze caps. From here on,
+    # Device._process_frame passes allow_demote=False into process_b5, so any
+    # later (unsolicited / reconnect-replayed) B5 may still ESCALATE a field or
+    # refresh its constraints, but can no longer silently DEMOTE one confirmed
+    # at boot. _apply_caps_to_fields logs + counts each blocked "cap killer".
+    status["meta"]["caps_finalized"] = True
 
 
 # ── Data frame processing (C0, C1, A1) ───────────────────────────────────

--- a/custom_components/blaueis_midea/lib/blaueis/core/status.py
+++ b/custom_components/blaueis_midea/lib/blaueis/core/status.py
@@ -90,6 +90,10 @@ def build_status(device: str = "unknown", glossary: dict | None = None) -> dict:
             "phase": "boot",
             "glossary_version": glossary["meta"]["version"],
             "b5_received": False,
+            # Set True by finalize_capabilities at the end of the one boot
+            # capability scan. While False, B5 frames may demote (boot pages +
+            # finalize); once True, post-boot B5s are escalate-only (caps frozen).
+            "caps_finalized": False,
             "frame_counts": {},
         },
         "fields": status_fields,

--- a/custom_components/blaueis_midea/strings.json
+++ b/custom_components/blaueis_midea/strings.json
@@ -74,6 +74,34 @@
           "forced_off": "Forced off"
         }
       }
+    },
+    "climate": {
+      "blaueis_ac": {
+        "state_attributes": {
+          "swing_mode": {
+            "state": {
+              "off": "Off",
+              "swing": "Swing",
+              "upper": "Upper",
+              "upper_middle": "Upper Middle",
+              "middle": "Middle",
+              "lower_middle": "Lower Middle",
+              "lower": "Lower"
+            }
+          },
+          "swing_horizontal_mode": {
+            "state": {
+              "off": "Off",
+              "swing": "Swing",
+              "left": "Left",
+              "left_center": "Left Center",
+              "center": "Center",
+              "right_center": "Right Center",
+              "right": "Right"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/custom_components/blaueis_midea/translations/en.json
+++ b/custom_components/blaueis_midea/translations/en.json
@@ -76,6 +76,34 @@
           "forced_off": "Forced off"
         }
       }
+    },
+    "climate": {
+      "blaueis_ac": {
+        "state_attributes": {
+          "swing_mode": {
+            "state": {
+              "off": "Off",
+              "swing": "Swing",
+              "upper": "Upper",
+              "upper_middle": "Upper Middle",
+              "middle": "Middle",
+              "lower_middle": "Lower Middle",
+              "lower": "Lower"
+            }
+          },
+          "swing_horizontal_mode": {
+            "state": {
+              "off": "Off",
+              "swing": "Swing",
+              "left": "Left",
+              "left_center": "Left Center",
+              "center": "Center",
+              "right_center": "Right Center",
+              "right": "Right"
+            }
+          }
+        }
+      }
     }
   },
   "exceptions": {

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -74,6 +74,40 @@ sys.modules["homeassistant.components.select"].SelectEntity = _RealSelectEntity
 sys.modules["homeassistant.components.switch"].SwitchEntity = _RealSwitchEntity
 
 
+# Climate base + enums must be real so the entity instantiates and its
+# bitwise supported_features / @property overrides behave like production.
+import enum  # noqa: E402
+
+
+class _RealClimateEntity:
+    pass
+
+
+class _ClimateEntityFeature(enum.IntFlag):
+    TARGET_TEMPERATURE = 1
+    FAN_MODE = 8
+    PRESET_MODE = 16
+    SWING_MODE = 32
+    TURN_ON = 128
+    TURN_OFF = 256
+    SWING_HORIZONTAL_MODE = 512
+
+
+class _HVACMode(str, enum.Enum):
+    OFF = "off"
+    AUTO = "auto"
+    COOL = "cool"
+    HEAT = "heat"
+    DRY = "dry"
+    FAN_ONLY = "fan_only"
+
+
+sys.modules.setdefault("homeassistant.components.climate", MagicMock())
+sys.modules["homeassistant.components.climate"].ClimateEntity = _RealClimateEntity
+sys.modules["homeassistant.components.climate"].ClimateEntityFeature = _ClimateEntityFeature
+sys.modules["homeassistant.components.climate"].HVACMode = _HVACMode
+
+
 class FakeState:
     """Mimics homeassistant.core.State for sensor readings."""
 

--- a/tests/unit/test_climate_fan_mode.py
+++ b/tests/unit/test_climate_fan_mode.py
@@ -1,0 +1,66 @@
+"""Option A fan-mode: an off-grid fan_speed blanks the tile (no synthetic
+"Custom").
+
+Instantiates the real climate entity against a stub coordinator (conftest mocks
+homeassistant.* incl. a real ClimateEntity base). __init__ reads only
+coordinator.host/port and device.available_fields; read() runs lazily in the
+fan_mode property. The base ClimateEntity is a bare stub here, so we assert on
+``_attr_fan_modes`` (which __init__ sets) rather than the base ``fan_modes``
+property; ``fan_mode`` is our own subclass property and resolves directly.
+"""
+
+from unittest.mock import MagicMock
+
+from custom_components.blaueis_midea.climate import BlaueisMideaClimate
+
+HOST, PORT = "127.0.0.1", 8765
+
+# Named presets exactly as the active cap (0x10) carries them (raw/label).
+# Off-grid raws (e.g. 55) have no entry here.
+FAN_VALUES = {
+    "ultra_low": {"raw": 1, "label": "Ultra Low"},
+    "low": {"raw": 40, "label": "Low"},
+    "medium": {"raw": 60, "label": "Medium"},
+    "high": {"raw": 80, "label": "High"},
+    "auto": {"raw": 102, "label": "Auto"},
+}
+
+
+def _entity(fan_speed_read):
+    avail = {
+        "fan_speed": {
+            "active_constraints": {
+                "values": FAN_VALUES,
+                # Present in the cap; Option A must ignore it (no "Custom").
+                "custom_value": {"label": "Custom"},
+            }
+        }
+    }
+    coord = MagicMock()
+    coord.host, coord.port = HOST, PORT
+    coord.device.available_fields = avail
+    coord.device.read = lambda name: fan_speed_read if name == "fan_speed" else None
+    return BlaueisMideaClimate(coord)
+
+
+def test_custom_not_in_fan_modes():
+    ent = _entity(fan_speed_read=None)
+    assert "Custom" not in ent._attr_fan_modes
+    assert ent._attr_fan_modes == ["Ultra Low", "Low", "Medium", "High", "Auto"]
+
+
+def test_offgrid_raw_blanks_fan_mode():
+    # raw 55 has no named preset -> Option A blanks the tile (None), not "Custom".
+    ent = _entity(fan_speed_read=55)
+    assert ent.fan_mode is None
+
+
+def test_ongrid_raw_resolves_to_preset():
+    ent = _entity(fan_speed_read=60)
+    assert ent.fan_mode == "Medium"
+
+
+def test_unknown_fan_speed_is_none():
+    # None read (pre-status) -> None, no crash, no "Custom".
+    ent = _entity(fan_speed_read=None)
+    assert ent.fan_mode is None

--- a/tests/unit/test_climate_swing_dynamic.py
+++ b/tests/unit/test_climate_swing_dynamic.py
@@ -1,0 +1,57 @@
+"""The swing option lists are computed LIVE from available_fields.
+
+``swing_modes`` / ``swing_horizontal_modes`` are plain @property overrides that
+call ``axis_options`` each read, not a cached __init__ snapshot. So if a cap
+leaves available_fields after setup, the offered options shrink immediately and
+the dropdown can never offer a vane position the set path then rejects.
+"""
+
+from unittest.mock import MagicMock
+
+from custom_components.blaueis_midea.climate import BlaueisMideaClimate
+
+HOST, PORT = "127.0.0.1", 8765
+V_SWING = "louver_swing_vertical"
+V_ANGLE = "louver_swing_angle_ud_enum"
+H_SWING = "louver_swing_horizontal"
+H_ANGLE = "louver_swing_angle_lr_enum"
+
+V_FULL = ["off", "swing", "upper", "upper_middle", "middle", "lower_middle", "lower"]
+H_FULL = ["off", "swing", "left", "left_center", "center", "right_center", "right"]
+
+
+def _entity(avail):
+    coord = MagicMock()
+    coord.host, coord.port = HOST, PORT
+    coord.device.available_fields = avail
+    coord.device.read = lambda name: None
+    return BlaueisMideaClimate(coord)
+
+
+def test_positions_listed_when_angle_available():
+    ent = _entity({V_SWING: {}, V_ANGLE: {}, H_SWING: {}, H_ANGLE: {}})
+    assert ent.swing_modes == V_FULL
+    assert ent.swing_horizontal_modes == H_FULL
+
+
+def test_options_recompute_live_when_angle_drops():
+    # Same dict object the entity reads -> mutating it = a live cap change.
+    avail = {V_SWING: {}, V_ANGLE: {}, H_SWING: {}, H_ANGLE: {}}
+    ent = _entity(avail)
+    assert "upper_middle" in ent.swing_modes
+
+    # Angle caps leave available_fields AFTER __init__ (no entity rebuild).
+    del avail[V_ANGLE]
+    del avail[H_ANGLE]
+
+    # Plain @property recomputes: positions gone, swing/off remain. The feature
+    # itself stays supported (the swing field is still present).
+    assert ent.swing_modes == ["off", "swing"]
+    assert ent.swing_horizontal_modes == ["off", "swing"]
+
+
+def test_swing_modes_none_when_feature_absent():
+    # Neither swing nor angle for either axis -> feature unsupported -> None.
+    ent = _entity({"fan_speed": {}})
+    assert ent.swing_modes is None
+    assert ent.swing_horizontal_modes is None

--- a/tests/unit/test_climate_translations.py
+++ b/tests/unit/test_climate_translations.py
@@ -1,0 +1,110 @@
+"""Consistency tests for the climate swing/vane translations.
+
+The custom swing_mode / swing_horizontal_mode option slugs only render with
+nice labels if (a) the entity sets a translation_key and (b) translations
+carry a label for every slug under
+entity.climate.<key>.state_attributes.<attr>.state.<slug>.
+
+These tests pin the translation files against the slug source (``_swing`` /
+``const``) and the glossary display labels, so adding/renaming a vane position
+without updating the translation fails loudly instead of shipping a raw slug.
+"""
+
+import json
+import pathlib
+
+import pytest
+
+from custom_components.blaueis_midea._swing import axis_options
+from custom_components.blaueis_midea.const import (
+    POS_LABELS,
+    SWING_AXES,
+    SWING_OFF,
+    SWING_ON,
+)
+
+COMPONENT = (
+    pathlib.Path(__file__).resolve().parents[2]
+    / "custom_components"
+    / "blaueis_midea"
+)
+TRANSLATION_KEY = "blaueis_ac"
+AXIS_ATTR = {"vertical": "swing_mode", "horizontal": "swing_horizontal_mode"}
+TRANSLATION_FILES = ["strings.json", "translations/en.json"]
+AXES = ["vertical", "horizontal"]
+
+
+def _load(name):
+    return json.loads((COMPONENT / name).read_text())
+
+
+def _attr_block(doc, axis):
+    return doc["entity"]["climate"][TRANSLATION_KEY]["state_attributes"][AXIS_ATTR[axis]]
+
+
+def _full_avail(axis):
+    f = SWING_AXES[axis]
+    return {f["swing"]: {}, f["angle"]: {}}
+
+
+def _glossary_field(name):
+    from blaueis.core.codec import load_glossary
+
+    for fields in load_glossary()["fields"].values():
+        if isinstance(fields, dict) and name in fields:
+            return fields[name]
+    raise AssertionError(f"{name} not in glossary")
+
+
+def test_translation_key_matches_code():
+    src = (COMPONENT / "climate.py").read_text()
+    assert f'_attr_translation_key = "{TRANSLATION_KEY}"' in src
+    for fname in TRANSLATION_FILES:
+        assert TRANSLATION_KEY in _load(fname)["entity"]["climate"]
+
+
+def test_strings_and_en_climate_blocks_identical():
+    # strings.json is the source template; translations/en.json is what HA
+    # actually loads. They must carry the same climate block.
+    assert _load("strings.json")["entity"]["climate"] == (
+        _load("translations/en.json")["entity"]["climate"]
+    )
+
+
+@pytest.mark.parametrize("fname", TRANSLATION_FILES)
+@pytest.mark.parametrize("axis", AXES)
+def test_every_option_slug_has_a_label(fname, axis):
+    states = _attr_block(_load(fname), axis)["state"]
+    expected = set(axis_options(axis, _full_avail(axis)))  # off, swing, 5 positions
+    assert set(states) == expected, f"{fname} {axis}: symdiff {set(states) ^ expected}"
+    assert all(isinstance(v, str) and v for v in states.values())
+
+
+@pytest.mark.parametrize("axis", AXES)
+def test_position_labels_match_glossary(axis):
+    states = _attr_block(_load("translations/en.json"), axis)["state"]
+    gloss = _glossary_field(SWING_AXES[axis]["angle"])["values"]
+    raw_to_label = {v["raw"]: v["label"] for v in gloss.values()}
+    for raw, slug in POS_LABELS[axis].items():
+        assert states[slug] == raw_to_label[raw], (
+            f"{axis} {slug}: en.json {states[slug]!r} != glossary {raw_to_label[raw]!r}"
+        )
+
+
+def test_swing_option_label_plain():
+    e = _load("translations/en.json")
+    v = _attr_block(e, "vertical")["state"]
+    h = _attr_block(e, "horizontal")["state"]
+    assert v[SWING_OFF] == h[SWING_OFF] == "Off"
+    # Plain "Swing" on both axes — the axis is conveyed by the position labels
+    # (Upper/Lower vs Left/Right) and the control, not the option text.
+    assert v[SWING_ON] == h[SWING_ON] == "Swing"
+
+
+def test_no_control_name_override():
+    # We intentionally do NOT override the swing control names; HA core supplies
+    # them (e.g. "Swing mode" / "Oszillationsart"). We translate only the option
+    # VALUES — that is what fixes the raw-slug rendering (e.g. "upper_middle").
+    e = _load("translations/en.json")
+    assert "name" not in _attr_block(e, "vertical")
+    assert "name" not in _attr_block(e, "horizontal")


### PR DESCRIPTION
Companion to fabcoded/blaueis-libmidea#1 — vendors that cap-freeze change.

## Changes
- **lib (vendored):** cap-freeze + cap-killer observability synced from `blaueis-libmidea` — post-boot B5 frames may escalate but no longer demote a field confirmed at the boot scan; blocked demotions are logged + counted.
- **climate — live swing options:** `swing_modes` / `swing_horizontal_modes` are now plain `@property` values computed live from `available_fields` instead of a cached `__init__` snapshot, so the dropdown never offers a vane position the set path would reject.
- **climate — fan (Option A):** an off-grid `fan_speed` blanks the tile (`fan_mode -> None`) instead of a synthetic "Custom" entry; the dropdown lists only the named presets. Removes the dead `_fan_custom_label` machinery.
- **climate — swing-label translations:** option values render proper labels (e.g. `upper_middle` → "Upper Middle", `left_center` → "Left Center") instead of raw slugs.
- `CHANGELOG.md` added.

## Tests
New `test_climate_fan_mode.py`, `test_climate_swing_dynamic.py`; existing `test_climate_translations.py`; `conftest.py` gains a real `ClimateEntity` base for instantiation. Full HA-side unit suite green (291).

## Verified live
Deployed to the dev unit: both axes list the vane positions; `middle` / `lower` / `right` / `swing` / `off` all set and device-confirmed; fan shows no "Custom"; and the new cap-killer log caught + blocked a real post-boot `0x09=not-supported` frame while positions stayed settable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
