### PR TITLE
climate: mode-aware presets + revert rejected/invalid selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Notable changes to the Blaueis Midea integration.
 ## [Unreleased]
 
 ### Fixed
+- **Climate presets are now mode-aware.** A preset invalid in the current
+  operating mode (e.g. Frost Protection in cool) is no longer offered in the
+  dropdown, so it can't be selected and rejected. Presets stay mutually
+  exclusive (only one active), the displayed selection is always one of the
+  offered options, and a rejected/unapplied preset now reverts the card to the
+  actually-active selection instead of leaving the attempted pick showing.
 - **Vane positions no longer silently break mid-session.** After boot, the
   device can push unsolicited B5 capability frames that inconsistently report
   the B0 vane-angle caps (0x09 / 0x0A) as not-supported. These were re-applied

--- a/custom_components/blaueis_midea/climate.py
+++ b/custom_components/blaueis_midea/climate.py
@@ -20,6 +20,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from blaueis.core.codec import walk_fields
+from blaueis.core.ux_gating import is_field_visible
+
 from . import BlaueisMideaConfigEntry
 from ._preflight import validate_or_raise
 from ._set_result import check_set_result
@@ -100,12 +103,19 @@ class BlaueisMideaClimate(ClimateEntity):
             if field_name in avail:
                 self._available_presets[field_name] = preset_name
 
+        # The preset list is computed LIVE (preset_modes property) so only
+        # presets valid in the current operating mode are offered — e.g.
+        # Frost Protection (heat-only) is hidden in cool, instead of being
+        # offered and then rejected by the device with a stale selection left
+        # showing. _preset_gdefs caches each preset field's glossary def for the
+        # visibility check.
+        self._preset_gdefs: dict[str, dict] = {}
         if self._available_presets:
             features |= ClimateEntityFeature.PRESET_MODE
-            self._attr_preset_modes = [
-                PRESET_NONE,
-                *self._available_presets.values(),
-            ]
+            all_fields = walk_fields(self._device.glossary)
+            self._preset_gdefs = {
+                f: all_fields.get(f, {}) for f in self._available_presets
+            }
 
         self._attr_supported_features = features
 
@@ -270,13 +280,40 @@ class BlaueisMideaClimate(ClimateEntity):
             return None
         return self._axis_mode("horizontal")
 
+    def _preset_visible(self, field_name: str) -> bool:
+        """Whether a preset is selectable in the current operating mode
+        (heat-only Frost Protection is hidden in cool, etc.)."""
+        return is_field_visible(
+            self._preset_gdefs.get(field_name, {}),
+            current_mode=self._device.read("operating_mode"),
+        )
+
+    @property
+    def preset_modes(self) -> list[str] | None:
+        """Live preset list: 'none' plus only the mutually-exclusive presets
+        valid in the current mode. Computed each read (not a cached __init__
+        snapshot), so the card never offers — and the base class never
+        accepts — a preset the device would reject in this mode."""
+        if not self._available_presets:
+            return None
+        return [
+            PRESET_NONE,
+            *(
+                name
+                for field, name in self._available_presets.items()
+                if self._preset_visible(field)
+            ),
+        ]
+
     @property
     def preset_mode(self) -> str | None:
-        """Return the active preset, or 'none'."""
+        """The active preset, or 'none'. Only a preset that is BOTH active and
+        valid in the current mode is reported, so the displayed selection
+        always matches an offered option."""
         if not self._available_presets:
             return None
         for field_name, preset_name in self._available_presets.items():
-            if self._device.read(field_name):
+            if self._device.read(field_name) and self._preset_visible(field_name):
                 return preset_name
         return PRESET_NONE
 
@@ -318,7 +355,8 @@ class BlaueisMideaClimate(ClimateEntity):
         await self._set_axis("horizontal", swing_horizontal_mode)
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
-        """Set preset — clears all other presets first."""
+        """Set preset — clears all other presets first (mutually exclusive,
+        so only one is ever active)."""
         changes = {}
         primary: set[str] = set()
         for field_name in self._available_presets:
@@ -330,7 +368,13 @@ class BlaueisMideaClimate(ClimateEntity):
                 primary.add(target_field)
         if changes:
             result = await self._device.set(**changes)
-            check_set_result(result, primary_fields=primary)
+            try:
+                check_set_result(result, primary_fields=primary)
+            finally:
+                # Re-push the real state so a rejected / unapplied preset
+                # reverts in the card to the actually-active one instead of
+                # leaving the attempted selection shown.
+                self.async_write_ha_state()
 
     async def async_turn_on(self) -> None:
         result = await self._device.set(power=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -80,7 +80,9 @@ import enum  # noqa: E402
 
 
 class _RealClimateEntity:
-    pass
+    # No-op state push so set-methods that re-sync the card can run in tests.
+    def async_write_ha_state(self):
+        pass
 
 
 class _ClimateEntityFeature(enum.IntFlag):

--- a/tests/unit/test_climate_preset.py
+++ b/tests/unit/test_climate_preset.py
@@ -1,0 +1,94 @@
+"""Preset handling: the list is mode-aware (only conflict-free, mode-valid
+presets are offered), the displayed selection is always an offered option, and
+a rejected/unapplied set re-syncs the card instead of leaving a stale pick.
+
+Real-glossary visible_in_modes anchoring these tests:
+    frost_protection: [heat]            eco_mode:   [cool, auto, dry]
+    turbo_mode:       [cool, heat]      sleep_mode: [cool, heat, dry, auto]
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from blaueis.core.codec import load_glossary
+from custom_components.blaueis_midea.climate import BlaueisMideaClimate
+
+HOST, PORT = "127.0.0.1", 8765
+PRESET_FIELDS = ["turbo_mode", "eco_mode", "sleep_mode", "frost_protection"]
+COOL, HEAT = 2, 4
+
+
+def _entity(mode, active=None, set_result=None):
+    """mode = operating_mode raw int; active = the preset field currently on."""
+    reads = {"operating_mode": mode}
+    for f in PRESET_FIELDS:
+        reads[f] = f == active
+    coord = MagicMock()
+    coord.host, coord.port = HOST, PORT
+    coord.device.available_fields = {f: {} for f in PRESET_FIELDS}
+    coord.device.glossary = load_glossary()
+    coord.device.read = lambda name: reads.get(name)
+    coord.device.set = AsyncMock(
+        return_value=set_result or {"rejected": {}, "results": {}}
+    )
+    return BlaueisMideaClimate(coord)
+
+
+def test_frost_hidden_in_cool():
+    modes = _entity(COOL).preset_modes
+    assert modes[0] == "none"
+    assert "Frost Protection" not in modes  # heat-only
+    assert {"Turbo", "ECO", "Sleep"} <= set(modes)
+
+
+def test_frost_offered_eco_hidden_in_heat():
+    modes = _entity(HEAT).preset_modes
+    assert "Frost Protection" in modes
+    assert "ECO" not in modes  # cool/auto/dry only
+    assert {"Turbo", "Sleep"} <= set(modes)
+
+
+def test_preset_mode_reports_active_valid():
+    ent = _entity(HEAT, active="frost_protection")
+    assert ent.preset_mode == "Frost Protection"
+    assert ent.preset_mode in ent.preset_modes  # selected is always offered
+
+
+def test_preset_mode_none_when_active_but_invalid_in_mode():
+    # frost active while in cool (transient inconsistency) -> not reported, so
+    # the displayed selection never falls outside the offered list.
+    ent = _entity(COOL, active="frost_protection")
+    assert ent.preset_mode == "none"
+    assert "Frost Protection" not in ent.preset_modes
+
+
+def test_preset_mode_none_when_idle():
+    assert _entity(COOL).preset_mode == "none"
+
+
+async def test_set_preset_clears_others_and_sets_target():
+    ent = _entity(HEAT)
+    await ent.async_set_preset_mode("Frost Protection")
+    kwargs = ent._device.set.call_args.kwargs
+    assert kwargs["frost_protection"] is True
+    # mutual exclusion: every other preset explicitly cleared
+    assert kwargs["turbo_mode"] is False
+    assert kwargs["eco_mode"] is False
+    assert kwargs["sleep_mode"] is False
+
+
+async def test_rejected_preset_resyncs_card():
+    # A device-layer rejection raises, but the finally must still re-push state
+    # so the card reverts to the real (none) selection instead of the pick.
+    ent = _entity(
+        COOL,
+        set_result={
+            "rejected": {"frost_protection": "requires mode [4], current=2"},
+            "results": {},
+        },
+    )
+    ent.async_write_ha_state = MagicMock()
+    with pytest.raises(Exception):
+        await ent.async_set_preset_mode("Frost Protection")
+    ent.async_write_ha_state.assert_called_once()


### PR DESCRIPTION
## Problem
Selecting a preset that's invalid in the current operating mode (e.g. **Frost Protection** while in cool) showed a "not available in cool mode" warning, but the card kept the unapplied selection instead of reverting to `none`.

## Fix (same pattern as the dynamic swing options)
- **`preset_modes` is now a live `@property`** listing `none` plus only the mutually-exclusive presets whose `ux.visible_in_modes` includes the current `operating_mode`. So Frost Protection isn't offered in cool (and the base class won't accept it), ECO isn't offered in heat, etc. — an invalid preset can't be picked in the first place.
- **`preset_mode`** reports the active preset only when it's *also* valid in the current mode, so the displayed selection is always one of the offered options.
- **`async_set_preset_mode`** re-pushes state in a `finally`, so any rejected/unapplied preset reverts the card to the real selection instead of leaving the pick showing.

Presets remain mutually exclusive (selecting one clears the others) — unchanged.

## Tests
New `test_climate_preset.py` (7 tests): mode-aware list both directions, valid-active display, active-but-invalid hidden, mutual exclusion, and revert-on-rejection. Full unit suite green (**298 passed**).

## Verified live
Deployed to the dev unit (cool): `preset_modes` is now `["none","Turbo","ECO","Sleep"]` — **Frost Protection no longer offered**; `preset_mode` = `none`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
