### PR TITLE
climate: power-gate presets (none-only when off)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ Notable changes to the Blaueis Midea integration.
 ## [Unreleased]
 
 ### Fixed
-- **Climate presets are now mode-aware.** A preset invalid in the current
-  operating mode (e.g. Frost Protection in cool) is no longer offered in the
-  dropdown, so it can't be selected and rejected. Presets stay mutually
-  exclusive (only one active), the displayed selection is always one of the
-  offered options, and a rejected/unapplied preset now reverts the card to the
+- **Climate presets are now power- and mode-aware.** While the unit is off no
+  presets are offered (they can't engage), and a preset invalid in the current
+  operating mode (e.g. Frost Protection in cool) is no longer offered either —
+  so neither can be selected and then rejected. Presets stay mutually exclusive
+  (only one active), the displayed selection is always one of the offered
+  options, and a rejected/unapplied preset reverts the card to the
   actually-active selection instead of leaving the attempted pick showing.
 - **Vane positions no longer silently break mid-session.** After boot, the
   device can push unsolicited B5 capability frames that inconsistently report

--- a/custom_components/blaueis_midea/climate.py
+++ b/custom_components/blaueis_midea/climate.py
@@ -290,12 +290,16 @@ class BlaueisMideaClimate(ClimateEntity):
 
     @property
     def preset_modes(self) -> list[str] | None:
-        """Live preset list: 'none' plus only the mutually-exclusive presets
-        valid in the current mode. Computed each read (not a cached __init__
-        snapshot), so the card never offers — and the base class never
-        accepts — a preset the device would reject in this mode."""
+        """Live preset list: 'none' plus only the presets selectable right now.
+        Computed each read (not a cached __init__ snapshot), so the card never
+        offers — and the base class never accepts — a preset the device would
+        reject. Presets only engage while running, so while powered off nothing
+        but 'none' is offered; otherwise only the mutually-exclusive presets
+        valid in the current mode (e.g. Frost Protection is hidden in cool)."""
         if not self._available_presets:
             return None
+        if not self._device.read("power"):
+            return [PRESET_NONE]
         return [
             PRESET_NONE,
             *(
@@ -307,11 +311,13 @@ class BlaueisMideaClimate(ClimateEntity):
 
     @property
     def preset_mode(self) -> str | None:
-        """The active preset, or 'none'. Only a preset that is BOTH active and
-        valid in the current mode is reported, so the displayed selection
-        always matches an offered option."""
+        """The active preset, or 'none'. Only a preset that is active AND
+        currently selectable (powered on, valid in the current mode) is
+        reported, so the displayed selection always matches an offered option."""
         if not self._available_presets:
             return None
+        if not self._device.read("power"):
+            return PRESET_NONE
         for field_name, preset_name in self._available_presets.items():
             if self._device.read(field_name) and self._preset_visible(field_name):
                 return preset_name
@@ -355,12 +361,16 @@ class BlaueisMideaClimate(ClimateEntity):
         await self._set_axis("horizontal", swing_horizontal_mode)
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
-        """Set preset — clears all other presets first (mutually exclusive,
+        """Set preset — clears the other presets first (mutually exclusive,
         so only one is ever active)."""
         changes = {}
         primary: set[str] = set()
+        # Only clear presets that are valid in the current mode: a mode-invalid
+        # one can't be active anyway, and sending it (even =off) just trips the
+        # mode gate and logs a spurious rejection.
         for field_name in self._available_presets:
-            changes[field_name] = False
+            if self._preset_visible(field_name):
+                changes[field_name] = False
         if preset_mode != PRESET_NONE:
             target_field = PRESET_NAME_TO_FIELD.get(preset_mode)
             if target_field and target_field in self._available_presets:

--- a/tests/unit/test_climate_preset.py
+++ b/tests/unit/test_climate_preset.py
@@ -19,9 +19,9 @@ PRESET_FIELDS = ["turbo_mode", "eco_mode", "sleep_mode", "frost_protection"]
 COOL, HEAT = 2, 4
 
 
-def _entity(mode, active=None, set_result=None):
+def _entity(mode, active=None, power=True, set_result=None):
     """mode = operating_mode raw int; active = the preset field currently on."""
-    reads = {"operating_mode": mode}
+    reads = {"operating_mode": mode, "power": power}
     for f in PRESET_FIELDS:
         reads[f] = f == active
     coord = MagicMock()
@@ -67,15 +67,32 @@ def test_preset_mode_none_when_idle():
     assert _entity(COOL).preset_mode == "none"
 
 
+def test_no_presets_offered_when_off():
+    # Presets only engage while running (the device power-gates them), so a
+    # powered-off unit offers nothing but 'none'.
+    ent = _entity(COOL, power=False)
+    assert ent.preset_modes == ["none"]
+    assert ent.preset_mode == "none"
+
+
+def test_active_preset_not_shown_when_off():
+    # Even if a preset flag is still set, while off it's neither displayed nor
+    # offered (it can't be engaged).
+    ent = _entity(COOL, active="turbo_mode", power=False)
+    assert ent.preset_mode == "none"
+    assert "Turbo" not in ent.preset_modes
+
+
 async def test_set_preset_clears_others_and_sets_target():
     ent = _entity(HEAT)
     await ent.async_set_preset_mode("Frost Protection")
     kwargs = ent._device.set.call_args.kwargs
     assert kwargs["frost_protection"] is True
-    # mutual exclusion: every other preset explicitly cleared
+    # mutual exclusion: the other mode-valid presets are cleared
     assert kwargs["turbo_mode"] is False
-    assert kwargs["eco_mode"] is False
     assert kwargs["sleep_mode"] is False
+    # eco is invalid in heat, so it isn't sent at all (would trip the mode gate)
+    assert "eco_mode" not in kwargs
 
 
 async def test_rejected_preset_resyncs_card():


### PR DESCRIPTION
Follow-up to #2 — fixes two live-observed gaps in the mode-aware preset change.

## Problems (found on the live unit)
1. **Presets were still listed while the AC was off.** `preset_modes` filtered by operating mode but not by power; the device power-gates presets (they can't be set while off), so selecting one while off was rejected and left a stale selection on the card.
2. **"Turbo doesn't work in cool"** turned out to be the same thing — it works fine when *on*; the failure was selecting it while *off*.

## Fix
- `preset_modes` returns `["none"]` while powered off; otherwise `none` + the presets valid in the current mode.
- `preset_mode` returns `none` while off (nothing engageable).
- `async_set_preset_mode` only clears presets valid in the current mode — a mode-invalid one can't be active anyway, and sending it tripped the mode gate with a spurious rejection log. The device's own mutex still forces conflicting presets off (verified live).

## Verified live (this time properly)
- **off** → `preset_modes = ["none"]`, no presets.
- **on / cool** → `preset_modes = ["none","Turbo","ECO","Sleep"]`; selecting **Turbo** engages (`preset_mode=Turbo`, `Sent 0x40 {'turbo_mode': True, ...}`), and the spurious `frost_protection` mode-gate warning is gone.

## Tests
+2 power-gate cases in `test_climate_preset.py`; full unit suite green (**300 passed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
