### PR TITLE
Phase 1: vendor decode-retention decoupling

### DIFF
--- a/custom_components/blaueis_midea/lib/blaueis/core/codec.py
+++ b/custom_components/blaueis_midea/lib/blaueis/core/codec.py
@@ -1188,10 +1188,11 @@ def build_scan_queue(
             # Count fields whose protocols OR capability.frames intersect
             # this frame's triggers — capability-gated fields show up via
             # the latter and the label should reflect the full coverage.
-            # Skip fields whose feature_available is 'excluded': they are
-            # discarded at decode time by process_data_frame, so showing
-            # them in the operator-facing label would inflate the count
-            # past what actually populates state.
+            # Skip fields whose feature_available is 'excluded': since the
+            # decode-retention split they ARE retained in state, but they are
+            # neither exposed (available_fields) nor polled (required_queries),
+            # so counting them would inflate the operator-facing coverage label
+            # past what the query cycle actually surfaces.
             covered = 0
             for fname, fdef in fields_by_name.items():
                 fa = status["fields"].get(fname, {}).get("feature_available", "always")

--- a/custom_components/blaueis_midea/lib/blaueis/core/process.py
+++ b/custom_components/blaueis_midea/lib/blaueis/core/process.py
@@ -279,9 +279,12 @@ def process_data_frame(
         if not status_field:
             continue
 
-        # Skip fields that are not available (excluded, or *capability* / *capability-opt*
-        # not yet resolved by B5 promotion)
-        if status_field["feature_available"] in ("excluded", "capability", "capability-opt"):
+        # Retain decoded values regardless of EXPOSURE so gating interlocks can
+        # read a field's live state even when it is hidden/excluded. Still skip the
+        # pre-B5 'capability'/'capability-opt' window: the decode is untrusted until
+        # B5 confirms which feature owns the byte. Exposure and polling stay gated at
+        # available_fields / required_queries — this loop governs RETENTION only.
+        if status_field["feature_available"] in ("capability", "capability-opt"):
             continue
 
         suppression = result.get("suppression")


### PR DESCRIPTION
## Phase 1 — vendor decode-retention decoupling

Mirrors the `process.py` / `codec.py` change from the libmidea `feat/decode-retention-phase1` PR. `process_data_frame` retains decoded values for confirmed-excluded fields (so gating interlocks can read live state) while exposure and polling stay gated. **No integration behaviour change** — excluded fields are still neither shown nor polled.

ha-midea unit tests green (300).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
