### PR TITLE
Gate engine G3: wire evaluate_offered into offering path (parity)

### DIFF
--- a/custom_components/blaueis_midea/_ux_mixin.py
+++ b/custom_components/blaueis_midea/_ux_mixin.py
@@ -19,34 +19,42 @@ Keeps the pattern out of each class body so adding a new platform
 
 from __future__ import annotations
 
-from blaueis.core.ux_gating import is_field_visible
+from blaueis.core.gate_eval import evaluate_offered
 
 
 def field_ux_available(coordinator, field_name: str) -> bool:
-    """Evaluate the glossary ``ux`` block for `field_name` against current state.
+    """Evaluate the field's offer gate for `field_name` against current state.
 
     Returns True (visible) when:
       - the coordinator is connected AND
       - the device is fresh (recent successful ingest) AND
-      - the field has no ``ux`` block (permissive default) OR
-      - the current mode is in ``ux.visible_in_modes`` (when that key exists) AND
-      - any ``ux.hardware_flag`` resolves truthy via the device's caps bitmap.
+      - the gate evaluator offers the field: logical mode (``ux.visible_in_modes``
+        / ``hardware_flag``) ∩ the capability-derived mode set (``gate.cap_mode``)
+        ∩ any runtime interlocks. A field with no ``gate:`` block reduces to the
+        prior ``is_field_visible`` behaviour.
 
     The ``device_fresh`` gate fades every UI-visible entity together
     when the AC stops responding (powered off at breaker, firmware
     crash, comms partition) without each platform needing its own
     staleness check.
+
+    ``power_on=True`` is intentional: the power axis stays off at this site
+    (power-state fading is the ``device_fresh`` guard above, unchanged), so this
+    is parity with the prior mode-only gate plus the now-live capability axis.
     """
     if not coordinator.connected:
         return False
     if not coordinator.device_fresh:
         return False
-    gdef = coordinator.device.field_gdef(field_name)
-    return is_field_visible(
+    dev = coordinator.device
+    gdef = dev.field_gdef(field_name)
+    return evaluate_offered(
         gdef,
-        current_mode=coordinator.device.read("operating_mode"),
-        caps=coordinator.device.caps_bitmap(),
-    )
+        mode=dev.read("operating_mode"),
+        power_on=True,
+        active_constraints=dev.active_constraints(field_name),
+        caps=dev.caps_bitmap(),
+    ).offered
 
 
 def field_writable_in_current_mode(coordinator, field_name: str) -> bool:

--- a/custom_components/blaueis_midea/climate.py
+++ b/custom_components/blaueis_midea/climate.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from blaueis.core.codec import walk_fields
-from blaueis.core.ux_gating import is_field_visible
+from blaueis.core.gate_eval import evaluate_offered
 
 from . import BlaueisMideaConfigEntry
 from ._preflight import validate_or_raise
@@ -282,11 +282,18 @@ class BlaueisMideaClimate(ClimateEntity):
 
     def _preset_visible(self, field_name: str) -> bool:
         """Whether a preset is selectable in the current operating mode
-        (heat-only Frost Protection is hidden in cool, etc.)."""
-        return is_field_visible(
+        (heat-only Frost Protection is hidden in cool, etc.).
+
+        ``power_on=True`` keeps the power axis off here — preset power-gating
+        already lives in ``preset_modes`` (none-only when off) — so this is parity
+        with the prior mode gate plus the now-live capability-mode axis (e.g. turbo
+        cap restricting which modes offer it)."""
+        return evaluate_offered(
             self._preset_gdefs.get(field_name, {}),
-            current_mode=self._device.read("operating_mode"),
-        )
+            mode=self._device.read("operating_mode"),
+            power_on=True,
+            active_constraints=self._device.active_constraints(field_name),
+        ).offered
 
     @property
     def preset_modes(self) -> list[str] | None:

--- a/custom_components/blaueis_midea/lib/blaueis/client/device.py
+++ b/custom_components/blaueis_midea/lib/blaueis/client/device.py
@@ -1195,6 +1195,15 @@ class Device:
     def read_full(self, field_name: str) -> dict | None:
         return read_field(self._status, field_name)
 
+    def active_constraints(self, field_name: str) -> dict | None:
+        """Cap-derived constraints for a field (valid_set / valid_range / step …).
+
+        Written by the B5 cap pass (`_apply_caps_to_fields`) and consumed by the
+        gate evaluator's capability-mode axis. Returns None when the field has no
+        live constraints yet (pre-B5 or no cap)."""
+        f = self._status["fields"].get(field_name)
+        return f.get("active_constraints") if f else None
+
     def read_all_available(self) -> dict[str, object]:
         """Read all available fields. Returns {name: value}."""
         return {fname: self.read(fname) for fname in self.available_fields}

--- a/custom_components/blaueis_midea/lib/blaueis/core/gate_eval.py
+++ b/custom_components/blaueis_midea/lib/blaueis/core/gate_eval.py
@@ -41,20 +41,30 @@ def _mode_name(mode: int | str | None) -> str | None:
     return None
 
 
+def _is_mode_raw(x: object) -> bool:
+    """True iff x is an operating-mode raw (int 1-5, excluding bool)."""
+    return isinstance(x, int) and not isinstance(x, bool) and x in MODE_INT_TO_NAME
+
+
 def _cap_mode_set(gate: dict, active_constraints: dict | None) -> set[str] | None:
     """Mode NAMES the active capability permits, or None when no cap-mode gate applies.
 
-    Only honoured when ``gate.cap_mode`` is declared — that marker is what makes the
-    live ``active_constraints.valid_set`` mean *operating-mode raws* rather than
-    field-value raws (the value-vs-mode axis trap). Without it we never reinterpret
-    a valid_set as modes.
+    Honoured only when ``gate.cap_mode`` is declared AND the live
+    ``active_constraints.valid_set`` is genuinely *operating-mode raws* (ints 1-5).
+    The pre-B5 permissive default carries a value-domain valid_set (e.g. turbo's
+    ``[False, True]`` on/off); reinterpreting that as modes would wrongly gate
+    everything to ``auto`` (True→1). So when the valid_set is not all mode-raws —
+    pre-B5, or a field-value constraint (the value-vs-mode axis trap) — the cap-mode
+    axis stays inert and the field falls back to its logical mode rule.
     """
-    if not gate.get("cap_mode") or not active_constraints:
+    if not gate.get("cap_mode") or not isinstance(active_constraints, dict):
         return None
     valid_set = active_constraints.get("valid_set")
-    if valid_set is None:
+    if not isinstance(valid_set, (list, tuple)) or not valid_set:
         return None
-    return {n for n in (_mode_name(r) for r in valid_set) if n is not None}
+    if not all(_is_mode_raw(r) for r in valid_set):
+        return None
+    return {MODE_INT_TO_NAME[r] for r in valid_set}
 
 
 def evaluate_offered(

--- a/tests/unit/test_climate_preset.py
+++ b/tests/unit/test_climate_preset.py
@@ -29,6 +29,10 @@ def _entity(mode, active=None, power=True, set_result=None):
     coord.device.available_fields = {f: {} for f in PRESET_FIELDS}
     coord.device.glossary = load_glossary()
     coord.device.read = lambda name: reads.get(name)
+    # No B5 caps applied in this fixture → cap-mode axis inert (a real device
+    # returns None here, not a MagicMock). Without this, turbo_mode's gate.cap_mode
+    # would read the auto-mock as an empty mode set and gate it off everywhere.
+    coord.device.active_constraints = lambda name: None
     coord.device.set = AsyncMock(
         return_value=set_result or {"rejected": {}, "results": {}}
     )


### PR DESCRIPTION
## Gate engine G3 — wire `evaluate_offered` into the offering path (parity)

Routes the two HA offering sites through the gate evaluator, making the **capability-mode axis live in production** while preserving behaviour on our unit. The `command.py` wire-mask stays on `is_field_visible` — the engine is advisory and must never gate wire behaviour.

- `_ux_mixin.field_ux_available` and `climate._preset_visible` now call `evaluate_offered(mode, power_on=True, active_constraints, caps)`. `power_on=True` keeps the power axis off at these sites (power fading stays at `device_fresh` / `preset_modes`, unchanged); `active_constraints` activates the cap-mode axis.
- **Parity on our unit:** turbo cap=1 → `[cool,heat]` == `visible_in_modes`; every field without a `gate:` block reduces to the prior `is_field_visible`. A unit whose turbo cap restricts modes (cool-only / heat-only) is now gated correctly.
- Vendored: `device.active_constraints` accessor + `gate_eval` cap-mode hardening.
- Test fixture: stub `device.active_constraints` (a real device returns `None` pre-B5; the `MagicMock` otherwise reads as an empty mode set).

ha-midea unit suite green (one pre-existing concurrency-timing flake in `test_ingress_hook`, unrelated; passes on retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
