### PR TITLE
[DRAFT] Gate engine G4: eco mode-fork live (live-test gated)

### DIFF
--- a/custom_components/blaueis_midea/_ux_mixin.py
+++ b/custom_components/blaueis_midea/_ux_mixin.py
@@ -68,6 +68,7 @@ def field_ux_available(coordinator, field_name: str) -> bool:
         power_on=True,
         active_constraints=dev.active_constraints(field_name),
         caps=dev.caps_bitmap(),
+        cap_values=dev.cap_values(),
         field_states=interlock_states(dev, gdef),
     ).offered
 

--- a/custom_components/blaueis_midea/climate.py
+++ b/custom_components/blaueis_midea/climate.py
@@ -295,6 +295,7 @@ class BlaueisMideaClimate(ClimateEntity):
             mode=self._device.read("operating_mode"),
             power_on=True,
             active_constraints=self._device.active_constraints(field_name),
+            cap_values=self._device.cap_values(),
             field_states=interlock_states(self._device, gdef),
         ).offered
 

--- a/custom_components/blaueis_midea/lib/blaueis/client/device.py
+++ b/custom_components/blaueis_midea/lib/blaueis/client/device.py
@@ -1204,6 +1204,19 @@ class Device:
         f = self._status["fields"].get(field_name)
         return f.get("active_constraints") if f else None
 
+    def cap_values(self) -> dict[str, int]:
+        """The unit's B5 capability bytes as ``{cap_id: raw}`` (e.g. ``{'0x12': 1}``).
+
+        Built from the accumulated ``capabilities_raw`` records; consumed by the
+        gate evaluator's mode-fork axis. Empty before any B5 cap has arrived."""
+        out: dict[str, int] = {}
+        for rec in self._status.get("capabilities_raw", []):
+            cap_id = str(rec.get("cap_id", "")).lower()
+            data = rec.get("data") or []
+            if cap_id and data:
+                out[cap_id] = data[0]
+        return out
+
     def read_all_available(self) -> dict[str, object]:
         """Read all available fields. Returns {name: value}."""
         return {fname: self.read(fname) for fname in self.available_fields}

--- a/custom_components/blaueis_midea/lib/blaueis/core/data/glossary.yaml
+++ b/custom_components/blaueis_midea/lib/blaueis/core/data/glossary.yaml
@@ -1694,6 +1694,15 @@ fields:
       ux:
         visible_in_modes: [cool, auto, dry]
         sources: own observation
+      gate:
+        mode_forks:
+          - {cap_id: '0x12', when_raw: 1, modes: [cool]}
+          - {cap_id: '0x12', when_raw: 2, modes: [cool, auto, dry]}
+        sources: own research
+        note: Cap 0x12 forks eco's applicable mode set — special-eco (raw 1) restricts
+          to cool, window-eco (raw 2) keeps cool/auto/dry. Raw 0 = eco absent (the
+          presence axis excludes it). Our unit cap=1, so eco is cool-only;
+          visible_in_modes over-offers auto/dry without this fork.
       mutual_exclusion:
         when_on:
           forces:

--- a/custom_components/blaueis_midea/lib/blaueis/core/gate_eval.py
+++ b/custom_components/blaueis_midea/lib/blaueis/core/gate_eval.py
@@ -67,6 +67,25 @@ def _cap_mode_set(gate: dict, active_constraints: dict | None) -> set[str] | Non
     return {MODE_INT_TO_NAME[r] for r in valid_set}
 
 
+def _mode_fork_set(gate: dict, cap_values: dict | None) -> set[str] | None:
+    """Mode NAMES from the first matching ``gate.mode_forks`` entry, or None.
+
+    A fork maps a capability byte value to an explicit mode set the way a
+    ``valid_set`` cannot (e.g. eco cool-only when 0x12==1 vs cool/auto/dry when
+    ==2). Returns None when no fork is declared or none matches the unit's cap
+    bytes — leaving the logical mode rule unrestricted (fail open).
+    """
+    forks = gate.get("mode_forks") or []
+    if not forks or not isinstance(cap_values, dict):
+        return None
+    for fork in forks:
+        cap_id = str(fork.get("cap_id", "")).lower()
+        if cap_id and cap_values.get(cap_id) == fork.get("when_raw"):
+            modes = fork.get("modes")
+            return set(modes) if isinstance(modes, (list, tuple)) else None
+    return None
+
+
 def evaluate_offered(
     field_gdef: dict | None,
     *,
@@ -75,6 +94,7 @@ def evaluate_offered(
     active_constraints: dict | None = None,
     field_states: dict | None = None,
     caps: dict | None = None,
+    cap_values: dict | None = None,
 ) -> GateVerdict:
     """Evaluate whether a field should be offered, across all gate axes.
 
@@ -82,7 +102,8 @@ def evaluate_offered(
     ``power_on`` from the decoded status, ``active_constraints`` from the field's
     cap-derived constraints (``status['fields'][f]['active_constraints']``),
     ``field_states`` a {name: value} map for interlock dependencies (their now-
-    retained decoded values), ``caps`` the B5 flag bitmap for ``hardware_flag``.
+    retained decoded values), ``caps`` the B5 flag bitmap for ``hardware_flag``,
+    ``cap_values`` a {cap_id: raw_byte} map of the unit's B5 caps for mode forks.
     """
     gdef = field_gdef or {}
     gate = gdef.get("gate") or {}
@@ -95,7 +116,12 @@ def evaluate_offered(
     # ── mode axis: logical (visible_in_modes / hardware_flag) ∩ cap-derived ──
     if not is_field_visible(gdef, current_mode=mode, caps=caps):
         blocked.append("mode")
-    cap_modes = _cap_mode_set(gate, active_constraints)
+    # Cap-derived mode set = intersection of every declared cap restriction:
+    # the cap_mode valid_set and the matching mode_fork. None ⇒ that axis inert.
+    cap_modes = None
+    for restriction in (_cap_mode_set(gate, active_constraints), _mode_fork_set(gate, cap_values)):
+        if restriction is not None:
+            cap_modes = restriction if cap_modes is None else (cap_modes & restriction)
     if cap_modes is not None:
         name = _mode_name(mode)
         # name is None → mode unknown (pre-first-poll); fail open, matching is_field_visible.

--- a/tests/unit/test_climate_preset.py
+++ b/tests/unit/test_climate_preset.py
@@ -19,8 +19,9 @@ PRESET_FIELDS = ["turbo_mode", "eco_mode", "sleep_mode", "frost_protection"]
 COOL, HEAT = 2, 4
 
 
-def _entity(mode, active=None, power=True, set_result=None):
-    """mode = operating_mode raw int; active = the preset field currently on."""
+def _entity(mode, active=None, power=True, set_result=None, cap_values=None):
+    """mode = operating_mode raw int; active = the preset field currently on.
+    cap_values = {cap_id: raw} for the gate mode-fork axis (default: none applied)."""
     reads = {"operating_mode": mode, "power": power}
     for f in PRESET_FIELDS:
         reads[f] = f == active
@@ -33,6 +34,7 @@ def _entity(mode, active=None, power=True, set_result=None):
     # returns None here, not a MagicMock). Without this, turbo_mode's gate.cap_mode
     # would read the auto-mock as an empty mode set and gate it off everywhere.
     coord.device.active_constraints = lambda name: None
+    coord.device.cap_values = lambda: (cap_values or {})
     coord.device.set = AsyncMock(
         return_value=set_result or {"rejected": {}, "results": {}}
     )
@@ -113,3 +115,25 @@ async def test_rejected_preset_resyncs_card():
     with pytest.raises(Exception):
         await ent.async_set_preset_mode("Frost Protection")
     ent.async_write_ha_state.assert_called_once()
+
+
+# ── G4: eco mode-fork live (special-eco cap → cool-only) ─────────────────
+AUTO, DRY = 1, 3
+
+
+def test_eco_offered_in_auto_without_caps():
+    # No caps → fork inert → eco offered per visible_in_modes (cool/auto/dry).
+    assert "ECO" in _entity(AUTO).preset_modes
+
+
+def test_eco_cool_only_with_special_eco_cap():
+    # Our unit: cap 0x12=1 (special eco) ⇒ eco offered in cool, hidden in auto/dry.
+    assert "ECO" in _entity(COOL, cap_values={"0x12": 1}).preset_modes
+    assert "ECO" not in _entity(AUTO, cap_values={"0x12": 1}).preset_modes
+    assert "ECO" not in _entity(DRY, cap_values={"0x12": 1}).preset_modes
+
+
+def test_eco_full_set_with_window_eco_cap():
+    # Window variant: cap 0x12=2 ⇒ eco keeps cool/auto/dry.
+    assert "ECO" in _entity(COOL, cap_values={"0x12": 2}).preset_modes
+    assert "ECO" in _entity(AUTO, cap_values={"0x12": 2}).preset_modes


### PR DESCRIPTION
## Gate engine G4 — eco mode-fork live (special-eco cap → cool-only)

> ⚠️ **DRAFT — DO NOT MERGE until live engagement test.** This **changes behaviour on our unit**: eco drops from auto/dry to cool-only.
>
> **Live test to clear this PR:** with cap `0x12=1`, confirm eco is offered in **cool**, **gone in auto/dry**, and an eco write still **sticks in cool** across a poll.

Wires `cap_values` into the two offering sites so `eco_mode.gate.mode_forks` applies. Window units (`0x12=2`) keep cool/auto/dry.

- `_ux_mixin` / `climate._preset_visible`: pass `cap_values=dev.cap_values()`.
- Vendored: mode-fork axis, `device.cap_values`, eco glossary fork.
- Tests: eco cool-only (`0x12=1`), full set (`0x12=2`), inert-without-caps (parity).

ha-midea unit suite green (302; 1 pre-existing flake deselected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
