### PR TITLE
[DRAFT] Gate engine G5: Turbo preset writes strong_wind (flip-back fix)

### DIFF
--- a/custom_components/blaueis_midea/const.py
+++ b/custom_components/blaueis_midea/const.py
@@ -17,8 +17,13 @@ DEBUG_RING_SIZE_MB = 5
 # ── Climate preset fields ──────────────────────────────────
 # Mutually exclusive performance/comfort presets.
 # Setting one clears all others. B5-gated: only confirmed fields appear.
+# The "Turbo" preset drives strong_wind (body[8] bit 5) — the actionable
+# boost bit the device acts on — NOT turbo_mode (body[10] bit 1), which does
+# not engage on this hardware (the write read back as 0 → preset flip-back).
+# turbo_mode is kept hidden (CLIMATE_EXCLUSIVE_FIELDS) rather than exposed as a
+# dead standalone switch; it is still decoded/retained for gating.
 CLIMATE_PRESET_FIELDS = {
-    "turbo_mode": "Turbo",
+    "strong_wind": "Turbo",
     "eco_mode": "ECO",
     "sleep_mode": "Sleep",
     "frost_protection": "Frost Protection",
@@ -59,6 +64,9 @@ CLIMATE_EXCLUSIVE_FIELDS = frozenset({
     "louver_swing_angle_ud_enum",
     "louver_swing_angle_lr_enum",
     *CLIMATE_PRESET_FIELDS.keys(),
+    # turbo_mode no longer backs the Turbo preset (strong_wind does); keep it
+    # climate-exclusive so the dead bit isn't surfaced as a standalone switch.
+    "turbo_mode",
 })
 
 # ── Swing & vane-position model (climate.py) ───────────────

--- a/tests/unit/test_climate_preset.py
+++ b/tests/unit/test_climate_preset.py
@@ -4,7 +4,7 @@ a rejected/unapplied set re-syncs the card instead of leaving a stale pick.
 
 Real-glossary visible_in_modes anchoring these tests:
     frost_protection: [heat]            eco_mode:   [cool, auto, dry]
-    turbo_mode:       [cool, heat]      sleep_mode: [cool, heat, dry, auto]
+    strong_wind:      [cool, heat, fan_only]   sleep_mode: [cool, heat, dry, auto]
 """
 
 from unittest.mock import AsyncMock, MagicMock
@@ -15,7 +15,7 @@ from blaueis.core.codec import load_glossary
 from custom_components.blaueis_midea.climate import BlaueisMideaClimate
 
 HOST, PORT = "127.0.0.1", 8765
-PRESET_FIELDS = ["turbo_mode", "eco_mode", "sleep_mode", "frost_protection"]
+PRESET_FIELDS = ["strong_wind", "eco_mode", "sleep_mode", "frost_protection"]
 COOL, HEAT = 2, 4
 
 
@@ -31,7 +31,7 @@ def _entity(mode, active=None, power=True, set_result=None, cap_values=None):
     coord.device.glossary = load_glossary()
     coord.device.read = lambda name: reads.get(name)
     # No B5 caps applied in this fixture → cap-mode axis inert (a real device
-    # returns None here, not a MagicMock). Without this, turbo_mode's gate.cap_mode
+    # returns None here, not a MagicMock). Without this, a field's gate.cap_mode
     # would read the auto-mock as an empty mode set and gate it off everywhere.
     coord.device.active_constraints = lambda name: None
     coord.device.cap_values = lambda: (cap_values or {})
@@ -84,7 +84,7 @@ def test_no_presets_offered_when_off():
 def test_active_preset_not_shown_when_off():
     # Even if a preset flag is still set, while off it's neither displayed nor
     # offered (it can't be engaged).
-    ent = _entity(COOL, active="turbo_mode", power=False)
+    ent = _entity(COOL, active="strong_wind", power=False)
     assert ent.preset_mode == "none"
     assert "Turbo" not in ent.preset_modes
 
@@ -95,7 +95,7 @@ async def test_set_preset_clears_others_and_sets_target():
     kwargs = ent._device.set.call_args.kwargs
     assert kwargs["frost_protection"] is True
     # mutual exclusion: the other mode-valid presets are cleared
-    assert kwargs["turbo_mode"] is False
+    assert kwargs["strong_wind"] is False
     assert kwargs["sleep_mode"] is False
     # eco is invalid in heat, so it isn't sent at all (would trip the mode gate)
     assert "eco_mode" not in kwargs

--- a/tests/unit/test_set_result.py
+++ b/tests/unit/test_set_result.py
@@ -152,7 +152,7 @@ class TestHumanize:
     def test_field_preset_label(self):
         assert _humanize_field("frost_protection") == "Frost Protection"
         assert _humanize_field("eco_mode") == "ECO"
-        assert _humanize_field("turbo_mode") == "Turbo"
+        assert _humanize_field("strong_wind") == "Turbo"  # Turbo preset → strong_wind
         assert _humanize_field("sleep_mode") == "Sleep"
 
     def test_field_fallback(self):


### PR DESCRIPTION
## Gate engine G5 — Turbo preset writes `strong_wind` (flip-back fix)

> ⚠️ **DRAFT — DO NOT MERGE until live engagement test.** Stacked on the G4 branch (base = `feat/gate-engine-g4-eco`); retarget to `main` after G4 merges.
>
> **Live test to clear this PR:** select **Turbo** → confirm the boost engages and the `strong_wind` readback **holds across a poll** (no flip-back).

The "Turbo" preset drove `turbo_mode` (body[10] bit 1), which doesn't engage on this hardware — the write read back as 0, so the preset flipped back to none. The actionable boost bit is `strong_wind` (body[8] bit 5); repoint the preset to it. The bit-position **anchor already machine-checks** `strong_wind C0:8:5` ≠ `turbo_mode C0:10:1`.

- `const.py`: `CLIMATE_PRESET_FIELDS` "Turbo" → `strong_wind`; `turbo_mode` kept climate-exclusive so the dead bit isn't surfaced as a standalone switch (still decoded/retained for gating).
- Tests: preset fixture + set-result label updated to `strong_wind`. ha-midea unit suite green (302).

Follow-up (post-confirm): cap-mode gating of the Turbo preset (restrict to the turbo cap's modes) — deferred until the write is live-confirmed, since `strong_wind`'s `visible_in_modes` includes `fan_only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
