### PR TITLE
Gate engine G6: wire interlock axis into offering path

### DIFF
--- a/custom_components/blaueis_midea/_ux_mixin.py
+++ b/custom_components/blaueis_midea/_ux_mixin.py
@@ -22,6 +22,20 @@ from __future__ import annotations
 from blaueis.core.gate_eval import evaluate_offered
 
 
+def interlock_states(device, gdef) -> dict | None:
+    """Build the {field: value} map a gate's interlocks depend on, or None.
+
+    Reads only the fields this gate's ``interlocks`` reference (usually 0), so the
+    cost is bounded per availability check. Values come from ``device.read`` (the
+    retained decoded value — hidden/excluded deps still resolve post-decode-retention)."""
+    deps = [
+        il.get("field")
+        for il in ((gdef or {}).get("gate") or {}).get("interlocks") or []
+        if il.get("field")
+    ]
+    return {d: device.read(d) for d in deps} if deps else None
+
+
 def field_ux_available(coordinator, field_name: str) -> bool:
     """Evaluate the field's offer gate for `field_name` against current state.
 
@@ -54,6 +68,7 @@ def field_ux_available(coordinator, field_name: str) -> bool:
         power_on=True,
         active_constraints=dev.active_constraints(field_name),
         caps=dev.caps_bitmap(),
+        field_states=interlock_states(dev, gdef),
     ).offered
 
 

--- a/custom_components/blaueis_midea/climate.py
+++ b/custom_components/blaueis_midea/climate.py
@@ -36,6 +36,7 @@ from .const import (
     SWING_AXES,
 )
 from ._swing import axis_mode, axis_options, axis_set_changes
+from ._ux_mixin import interlock_states
 from .coordinator import BlaueisMideaCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -288,11 +289,13 @@ class BlaueisMideaClimate(ClimateEntity):
         already lives in ``preset_modes`` (none-only when off) — so this is parity
         with the prior mode gate plus the now-live capability-mode axis (e.g. turbo
         cap restricting which modes offer it)."""
+        gdef = self._preset_gdefs.get(field_name, {})
         return evaluate_offered(
-            self._preset_gdefs.get(field_name, {}),
+            gdef,
             mode=self._device.read("operating_mode"),
             power_on=True,
             active_constraints=self._device.active_constraints(field_name),
+            field_states=interlock_states(self._device, gdef),
         ).offered
 
     @property

--- a/custom_components/blaueis_midea/lib/blaueis/core/data/glossary.yaml
+++ b/custom_components/blaueis_midea/lib/blaueis/core/data/glossary.yaml
@@ -4355,6 +4355,19 @@ fields:
       ux:
         visible_in_modes: [cool, heat, fan_only]
         sources: community protocol research
+      gate:
+        interlocks:
+          - field: auxiliary_heat_level
+            at: 'C0:9:4..3'
+            blocks_when: nonzero
+            modes: [heat, auto]
+        sources: own research
+        note: The boost is gated off while the auxiliary electric heater (PTC) is
+          engaged. auxiliary_heat_level (C0:9 bits 3-4) is mode-multiplexed with
+          eco_mode (bit 4) in cool/dry, so the interlock is scoped to heat/auto
+          where the bits carry the PTC stage. Vacuous on a unit without PTC
+          (cap 0x19=0 ⇒ auxiliary_heat_level reads 0). signoff tbd — not
+          live-confirmed on this hardware (no PTC); faithful to the disable rule.
       mutual_exclusion:
         when_on:
           forces:

--- a/custom_components/blaueis_midea/lib/blaueis/core/data/glossary_schema.json
+++ b/custom_components/blaueis_midea/lib/blaueis/core/data/glossary_schema.json
@@ -913,6 +913,11 @@
                 "enum": ["nonzero", "truthy", "zero", "off"],
                 "description": "Polarity: block the offer when the dependency state is nonzero/truthy (default) or zero/off."
               },
+              "modes": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Operating modes in which this interlock applies. Omit = all modes. Required when the dependency bit is mode-multiplexed (e.g. auxiliary_heat_level shares C0:9 bit4 with eco_mode) so it isn't misread outside its meaningful modes."
+              },
               "note": { "type": "string" }
             }
           }

--- a/custom_components/blaueis_midea/lib/blaueis/core/gate_eval.py
+++ b/custom_components/blaueis_midea/lib/blaueis/core/gate_eval.py
@@ -14,7 +14,7 @@ Schema (all keys optional; see gating-audit design doc):
       requires_power: true            # default true
       cap_mode: {cap_id: '0x1A'}      # active cap's valid_set IS operating-mode raws
       interlocks:                     # B1 dual-key cross-feature gates
-        - {field: ptc_state, at: 'C0:9:4..3', blocks_when: nonzero}
+        - {field: auxiliary_heat_level, at: 'C0:9:4..3', blocks_when: nonzero, modes: [heat, auto]}
       mutex_group: breeze             # declared; the existing cascade enforces it
 """
 from __future__ import annotations
@@ -104,6 +104,16 @@ def evaluate_offered(
 
     # ── interlock axis: cross-feature live state (B1 fail-open if unknown) ──
     for il in gate.get("interlocks") or []:
+        # Optional mode guard: an interlock that reads a mode-multiplexed bit
+        # (e.g. auxiliary_heat_level shares C0:9 bit4 with eco_mode) is only
+        # meaningful in the modes where that bit carries the dependency's value.
+        # Outside those modes the interlock is inactive (the bit means something
+        # else), so skip it rather than misread a neighbour field's bit.
+        il_modes = il.get("modes")
+        if il_modes is not None:
+            name = _mode_name(mode)
+            if name is None or name not in il_modes:
+                continue
         fname = il.get("field")
         state = (field_states or {}).get(fname) if fname else None
         if state is None:

--- a/tests/unit/test_interlock_gating.py
+++ b/tests/unit/test_interlock_gating.py
@@ -1,0 +1,50 @@
+"""Interlock axis wired through field_ux_available (gate engine G6).
+
+strong_wind declares an interlock: the boost is gated off while the auxiliary
+electric heater (auxiliary_heat_level) is engaged, scoped to heat/auto so the
+mode-multiplexed bit isn't misread in cool. Vacuous on our unit (no PTC ⇒
+auxiliary_heat_level reads 0); these drive the dependency value directly to
+prove the wiring end-to-end.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from blaueis.core.codec import load_glossary, walk_fields
+
+from custom_components.blaueis_midea._ux_mixin import field_ux_available
+
+COOL, HEAT = 2, 4
+
+
+def _coord(gdef, reads):
+    coord = MagicMock()
+    coord.connected = True
+    coord.device_fresh = True
+    coord.device.field_gdef.return_value = gdef
+    coord.device.read = lambda n: reads.get(n)
+    coord.device.caps_bitmap.return_value = {}
+    coord.device.active_constraints.return_value = None
+    return coord
+
+
+def _strong_wind():
+    return walk_fields(load_glossary())["strong_wind"]
+
+
+def test_boost_blocked_in_heat_while_elecheat_on():
+    coord = _coord(_strong_wind(), {"operating_mode": HEAT, "auxiliary_heat_level": 1})
+    assert field_ux_available(coord, "strong_wind") is False
+
+
+def test_boost_offered_in_heat_without_elecheat():
+    # Our unit: no PTC ⇒ auxiliary_heat_level reads 0 ⇒ boost offered.
+    coord = _coord(_strong_wind(), {"operating_mode": HEAT, "auxiliary_heat_level": 0})
+    assert field_ux_available(coord, "strong_wind") is True
+
+
+def test_boost_offered_in_cool_despite_bit_set():
+    # In cool the C0:9 bit means eco, not PTC — the mode guard keeps the boost
+    # offered rather than misreading the neighbour's bit as elec-heat.
+    coord = _coord(_strong_wind(), {"operating_mode": COOL, "auxiliary_heat_level": 1})
+    assert field_ux_available(coord, "strong_wind") is True


### PR DESCRIPTION
## Gate engine G6 — wire interlock axis into the offering path

Wires `field_states` into the two offering sites so `gate.interlocks` evaluate. `strong_wind` now carries an interlock (boost gated off while the aux electric heater is engaged, scoped to heat/auto). **Vacuous on our unit** (no PTC ⇒ `auxiliary_heat_level` reads 0) → no behaviour change here.

- `_ux_mixin.interlock_states()` — builds the `{dep: value}` map a gate's interlocks need (only the referenced deps; reads the retained decoded value).
- Vendored: interlock mode-guard, `strong_wind` interlock, schema `modes` field.
- `test_interlock_gating` — end-to-end via `field_ux_available`: blocked in heat with PTC, offered without, offered in cool despite the mode-muxed bit.

ha-midea unit suite green (302; 1 pre-existing flake deselected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
