### PR TITLE
feat: write-path gate (reasoned pre-flight validation)

### DIFF
--- a/custom_components/blaueis_midea/_preflight.py
+++ b/custom_components/blaueis_midea/_preflight.py
@@ -64,6 +64,52 @@ def _mode_label(coord: BlaueisMideaCoordinator, token: str | None) -> str:
     return token.replace("_", " ").title()
 
 
+def _current_mode_label(coord: BlaueisMideaCoordinator) -> str:
+    """Label for the device's current operating mode (raw byte → token → label)."""
+    raw = coord.device.read("operating_mode")
+    if raw is None:
+        return "unknown"
+    if isinstance(raw, str):
+        return _mode_label(coord, raw)
+    op_def = coord.device.field_gdef("operating_mode") or {}
+    for token, vdef in (op_def.get("values") or {}).items():
+        if isinstance(vdef, dict) and vdef.get("raw") == raw:
+            return _mode_label(coord, token)
+    return str(raw)
+
+
+def _raise_gate_block(coord: BlaueisMideaCoordinator, field_name: str, blocked_by: list[str]) -> None:
+    """Translate an offer-gate ``blocked_by`` into a ServiceValidationError.
+
+    Mode / capability-mode blocks read as "not active in this mode"; an interlock
+    block names the conflicting feature. Same predicate as entity availability
+    (``field_gate_verdict``), so the error a write raises matches the greying.
+    """
+    label = _field_label(coord, field_name)
+    interlock = next((b for b in blocked_by if b.startswith("interlock:")), None)
+    mode_blocked = any(b == "mode" or b.startswith("cap_mode:") for b in blocked_by)
+
+    if interlock and not mode_blocked:
+        blocker_field = interlock.split(":", 1)[1]
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="field_blocked_by_feature",
+            translation_placeholders={
+                "field": label,
+                "blocker": _field_label(coord, blocker_field),
+            },
+        )
+    # mode / cap_mode (or any other axis) → wrong operating mode
+    raise ServiceValidationError(
+        translation_domain=DOMAIN,
+        translation_key="field_inactive_in_mode",
+        translation_placeholders={
+            "field": label,
+            "mode": _current_mode_label(coord),
+        },
+    )
+
+
 def validate_or_raise(
     coord: BlaueisMideaCoordinator,
     field_name: str,
@@ -71,12 +117,20 @@ def validate_or_raise(
 ) -> None:
     """Run the validator; raise ``ServiceValidationError`` on non-Ok.
 
-    The validator's outcome shape maps onto translation keys declared in
-    ``translations/<lang>.json``:
+    Two layers, both raising ``ServiceValidationError`` with a translation key:
 
-    - :class:`OutOfRange`    → ``value_out_of_range``
-    - :class:`NotInEnum`     → ``value_not_in_enum``
-    - :class:`ModeDisallowed`→ ``field_inactive_in_mode``
+    1. **Offer gate** (``field_gate_verdict`` — the same predicate that drives
+       entity availability): blocks a write the field isn't offered for right now.
+       - mode / capability-mode → ``field_inactive_in_mode``
+       - runtime interlock      → ``field_blocked_by_feature``
+       Running this first means the *write rejection* a user gets always matches
+       the *greying* they see, and a service call / automation can't slip a write
+       past an interlock or capability-mode restriction (which the lib mode-fence
+       alone would not catch).
+    2. **Value validator** (``validate_set``):
+       - :class:`OutOfRange`    → ``value_out_of_range``
+       - :class:`NotInEnum`     → ``value_not_in_enum``
+       - :class:`ModeDisallowed`→ ``field_inactive_in_mode``
 
     :class:`FieldUnknown` is silently passed through — service handlers
     only call this for fields they own (entity → field_name binding is
@@ -85,6 +139,15 @@ def validate_or_raise(
 
     Booleans are not range-checked (handled inside the validator).
     """
+    # Lazy import: _ux_mixin pulls the vendored gate evaluator; importing it at
+    # module level here loads that chain too early during test collection and trips
+    # the select.py / stdlib-select shadow. At call time everything is loaded.
+    from ._ux_mixin import field_gate_verdict
+
+    verdict = field_gate_verdict(coord, field_name)
+    if not verdict.offered:
+        _raise_gate_block(coord, field_name, verdict.blocked_by)
+
     outcome = validate_set(
         field_name, value, coord.device.status, coord.device.glossary
     )

--- a/custom_components/blaueis_midea/_ux_mixin.py
+++ b/custom_components/blaueis_midea/_ux_mixin.py
@@ -19,7 +19,7 @@ Keeps the pattern out of each class body so adding a new platform
 
 from __future__ import annotations
 
-from blaueis.core.gate_eval import evaluate_offered
+from blaueis.core.gate_eval import GateVerdict, evaluate_offered
 
 
 def interlock_states(device, gdef) -> dict | None:
@@ -60,6 +60,21 @@ def field_ux_available(coordinator, field_name: str) -> bool:
         return False
     if not coordinator.device_fresh:
         return False
+    return field_gate_verdict(coordinator, field_name).offered
+
+
+def field_gate_verdict(coordinator, field_name: str) -> GateVerdict:
+    """Evaluate the full offer gate for `field_name` and return the verdict.
+
+    Single source of the gate predicate — used both by ``field_ux_available``
+    (which only needs ``.offered``) and by the write pre-flight
+    (``_preflight.validate_or_raise``, which surfaces ``.blocked_by`` as a
+    user-facing error). Keeping one call site guarantees the *availability* the
+    user sees and the *write rejection* they'd get can never disagree.
+
+    ``power_on=True`` keeps the power axis inert here, matching the offering
+    sites (power-state fading is handled by ``device_fresh`` / preset gating).
+    """
     dev = coordinator.device
     gdef = dev.field_gdef(field_name)
     return evaluate_offered(
@@ -70,7 +85,7 @@ def field_ux_available(coordinator, field_name: str) -> bool:
         caps=dev.caps_bitmap(),
         cap_values=dev.cap_values(),
         field_states=interlock_states(dev, gdef),
-    ).offered
+    )
 
 
 def field_writable_in_current_mode(coordinator, field_name: str) -> bool:

--- a/custom_components/blaueis_midea/translations/en.json
+++ b/custom_components/blaueis_midea/translations/en.json
@@ -115,6 +115,9 @@
     },
     "field_inactive_in_mode": {
       "message": "{field} cannot be set while operating mode is {mode}."
+    },
+    "field_blocked_by_feature": {
+      "message": "{field} cannot be set while {blocker} is active."
     }
   }
 }

--- a/tests/unit/test_write_path_gate.py
+++ b/tests/unit/test_write_path_gate.py
@@ -1,0 +1,78 @@
+"""Write-path gate: validate_or_raise runs the offer gate before the value check.
+
+A blocked write now raises ServiceValidationError naming the axis — mode /
+capability-mode → field_inactive_in_mode; runtime interlock → field_blocked_by_feature
+— instead of silently greying or surfacing a post-send rejection. Uses the real
+strong_wind gate block (visible_in_modes [cool,heat,fan_only] + an interlock on
+auxiliary_heat_level scoped to heat/auto).
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.exceptions import ServiceValidationError
+
+# Import the integration package first (its __init__ front-loads the vendored
+# `blaueis` lib path) before importing blaueis directly.
+from custom_components.blaueis_midea._preflight import validate_or_raise
+from custom_components.blaueis_midea._ux_mixin import field_ux_available
+
+from blaueis.core.codec import load_glossary, walk_fields
+
+GLOSSARY = load_glossary()
+FIELDS = walk_fields(GLOSSARY)
+COOL, DRY, HEAT = 2, 3, 4
+
+
+def _coord(mode, *, aux_heat=0, active_constraints=None, cap_values=None):
+    reads = {"operating_mode": mode, "auxiliary_heat_level": aux_heat}
+    coord = MagicMock()
+    coord.connected = True
+    coord.device_fresh = True
+    coord.hass.config.language = "en"
+    coord.device.field_gdef = lambda n: FIELDS.get(n)
+    coord.device.read = lambda n: reads.get(n)
+    coord.device.active_constraints = lambda n: active_constraints
+    coord.device.caps_bitmap = lambda: {}
+    coord.device.cap_values = lambda: (cap_values or {})
+    coord.device.status = {"fields": {}}
+    coord.device.glossary = GLOSSARY
+    return coord
+
+
+def test_blocked_in_wrong_mode_raises_inactive():
+    coord = _coord(DRY)  # strong_wind not offered in dry
+    with pytest.raises(ServiceValidationError) as exc:
+        validate_or_raise(coord, "strong_wind", True)
+    assert exc.value.translation_key == "field_inactive_in_mode"
+
+
+def test_blocked_by_interlock_raises_feature():
+    coord = _coord(HEAT, aux_heat=1)  # heat + elec-heat engaged → interlock blocks
+    with pytest.raises(ServiceValidationError) as exc:
+        validate_or_raise(coord, "strong_wind", True)
+    assert exc.value.translation_key == "field_blocked_by_feature"
+    # names the blocking feature
+    assert "blocker" in (exc.value.translation_placeholders or {})
+
+
+def test_offered_passes_no_raise():
+    # cool, no elec-heat → strong_wind offered → gate passes (value validator then Ok)
+    coord = _coord(COOL, aux_heat=0)
+    validate_or_raise(coord, "strong_wind", True)
+
+
+def test_interlock_inactive_outside_guard_modes():
+    # in cool the interlock's mode guard (heat/auto) is inactive, so a set bit
+    # on the mode-muxed dependency does NOT block the write.
+    coord = _coord(COOL, aux_heat=1)
+    validate_or_raise(coord, "strong_wind", True)
+
+
+def test_field_ux_available_parity_via_shared_verdict():
+    # the refactor: availability and the write gate share field_gate_verdict.
+    assert field_ux_available(_coord(COOL), "strong_wind") is True
+    assert field_ux_available(_coord(DRY), "strong_wind") is False
+    assert field_ux_available(_coord(HEAT, aux_heat=1), "strong_wind") is False


### PR DESCRIPTION
## Write-path gate — pre-flight uses the offer gate, with reasoned errors

Fixes the gap from the gate-feedback analysis: the **write** path validated only `valid_modes` + range + enum, so the new gate axes (`cap_mode`, `mode_forks`, **interlocks**) had *no* functional enforcement — only greying — and a service call / automation could slip a blocked write through. Blocked writes also gave no *reason*.

Now `validate_or_raise` runs the **same predicate as entity availability** (`field_gate_verdict` → `evaluate_offered`) before the value check, and raises `ServiceValidationError` naming the axis:
- mode / capability-mode → `field_inactive_in_mode`
- runtime interlock → **`field_blocked_by_feature`** (names the conflicting feature)

So the *write rejection* a user gets always matches the *greying* they see.

### Changes
- `_ux_mixin.field_gate_verdict()` — one place computes the gate verdict; `field_ux_available` delegates to it (behaviour-preserving).
- `_preflight.validate_or_raise()` — gate first (reasoned error), then the existing value validator. Lazy import of `field_gate_verdict` to dodge the `select.py`/stdlib-`select` import shadow at test collection.
- new translation key `field_blocked_by_feature`.
- tests: blocked-in-mode, blocked-by-interlock, offered-passes, mode-guard-inactive, availability parity.

ha-midea-only (the evaluator is already vendored). Interlocks become *enforcing* on write — vacuous on our unit (no PTC), correct for PTC units. Suite green (310); no vendored change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
